### PR TITLE
General improvements to installation guide and docker-compose file

### DIFF
--- a/.github/workflows/dockerhub-build-push.yml
+++ b/.github/workflows/dockerhub-build-push.yml
@@ -1,4 +1,4 @@
-name: Build and Push to DockerHub
+name: Docker Build
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ A single Docker container running both PiHole and Unbound.
 [![Docker Build Status](https://github.com/stinobytes/pihole-unbound/actions/workflows/dockerhub-build-push.yml/badge.svg)](https://github.com/stinobytes/pihole-unbound/actions/workflows/dockerhub-build-push.yml)
 
 This setup contains:
-- PiHole (using [official image](https://hub.docker.com/r/pihole/pihole)).
+- PiHole (using the [official image](https://hub.docker.com/r/pihole/pihole)).
 - Unbound DNS resolver, configured with DNS over TLS.
 
 > [!NOTE]
 > This setup uses host network mode, which means the container shares the network stack with the host.
-> This is optimal for DNS services but means the container has direct access to the host network.
+> This is optimal for DNS services but means the container has direct access to the host network. **It is highly recommended to run this behind a firewall**.
 
 
 ## Prerequisites
@@ -21,7 +21,7 @@ This setup contains:
 ## Setup
 
 > [!IMPORTANT]
-> Before starting the container, ensure no other services are using ports 53 (DNS), 80 (HTTP), and 443 (HTTPS) on your host machine.
+> Before starting, ensure no other services are using ports 53 (DNS), 80 (HTTP), and 443 (HTTPS) on your host machine.
 >
 > If you are installing this on Ubuntu (17.10+) or Fedora (33+), follow these steps first: https://github.com/pi-hole/docker-pi-hole/#installing-on-ubuntu-or-fedora
 >
@@ -104,11 +104,11 @@ docker exec pihole-unbound pihole setpassword "your_password"
 
 ### 3. Set PiHole as your DNS server
 
-There are multiple ways to do this, [it is recommended to follow the official PiHole FAQ](https://discourse.pi-hole.net/t/how-do-i-configure-my-devices-to-use-pi-hole-as-their-dns-server/245), it has all the different ways explained.
+There are multiple ways to do this, [it is recommended to follow the official PiHole FAQ](https://discourse.pi-hole.net/t/how-do-i-configure-my-devices-to-use-pi-hole-as-their-dns-server/245). It has all the different ways explained.
 
-### 4. Verify DNS Resolution
+### 4. Verify DNS resolution
 
-After setup, verify Pi-hole and Unbound are working correctly:
+After setup, verify Pi-hole and Unbound are working correctly (change `<server-ip-address>` to your server's IP address):
 ```bash
 # Test Pi-hole DNS resolution
 dig example.com @<server-ip-address>
@@ -121,7 +121,12 @@ docker exec pihole-unbound dig example.com @127.0.0.1 -p 5335
 
 By default, PiHole comes with [Steven Black's blocklist](https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts). This may or may not be enough to fit your needs.
 
-**(recommended)** In the PiHole admin interface (under `Lists`), you can add additional blocklists. I recommend this source: https://firebog.net/
+**(recommended)** In the PiHole admin interface (under `Lists`), you can add additional blocklists. I recommend this source: https://firebog.net/.
+
+> [!TIP]
+> You can add multiple lists at once, seperated by a space. If you are using firebog, you can copy and paste multple lines from each section.
+
+After adding new lists you should update Gravity. Go to `Tools` > `Update Gravity` and press the update button. Stay on that page until the update has finished.
 
 ### 6. Container updates
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This setup contains:
 
 ## Setup
 
-> [!WARNING]
+> [!IMPORTANT]
 > Before starting the container, ensure no other services are using ports 53 (DNS), 80 (HTTP), and 443 (HTTPS) on your host machine.
 >
 > If you are installing this on Ubuntu (17.10+) or Fedora (33+), follow these steps first: https://github.com/pi-hole/docker-pi-hole/#installing-on-ubuntu-or-fedora
@@ -32,107 +32,107 @@ This setup contains:
 
 ### 1. Prepare the environment
 
-- 1.1. Create a folder for the project:
-  ```bash
-  mkdir pihole-unbound
-  cd pihole-unbound
-  ```
+1.1. Create a folder for the project:
+```bash
+mkdir pihole-unbound
+cd pihole-unbound
+```
 
-- 1.2. Create the `docker-compose.yaml` file with the following content:
-  ```yaml
-  services:
-    pihole-unbound:
-      container_name: pihole-unbound
-      image: stinobytes/pihole-unbound:latest
-      network_mode: host
-      environment:
-        PIHOLE_UID: ${HOST_UID}
-        PIHOLE_GID: ${HOST_GID}
-        TZ: ${TZ}
-        FTLCONF_dns_listeningMode: "all"
-        FTLCONF_dns_upstreams: 127.0.0.1#5335
-      volumes:
-        - './config/etc-pihole:/etc/pihole'
-        - './config/etc-dnsmasq.d:/etc/dnsmasq.d'
-      cap_add:
-        - NET_BIND_SERVICE
-        - NET_ADMIN
-        - SYS_NICE
-      healthcheck:
-        test: ["CMD", "dig", "@127.0.0.1", "-p", "53", "pi.hole"]
-        interval: 30s
-        timeout: 10s
-        retries: 3
-      restart: unless-stopped
-  ```
+1.2. Create the `docker-compose.yaml` file with the following content:
+```yaml
+services:
+  pihole-unbound:
+    container_name: pihole-unbound
+    image: stinobytes/pihole-unbound:latest
+    network_mode: host
+    environment:
+      PIHOLE_UID: ${HOST_UID}
+      PIHOLE_GID: ${HOST_GID}
+      TZ: ${TZ}
+      FTLCONF_dns_listeningMode: "all"
+      FTLCONF_dns_upstreams: 127.0.0.1#5335
+    volumes:
+      - './config/etc-pihole:/etc/pihole'
+      - './config/etc-dnsmasq.d:/etc/dnsmasq.d'
+    cap_add:
+      - NET_BIND_SERVICE
+      - NET_ADMIN
+      - SYS_NICE
+    healthcheck:
+      test: ["CMD", "dig", "@127.0.0.1", "-p", "53", "pi.hole"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+```
 
-- 1.3. Create the `.env` file:
-  ```bash
-  echo "HOST_UID=$(id -u)" > .env
-  echo "HOST_GID=$(id -g)" >> .env
-  ```
+1.3. Create the `.env` file:
+```bash
+echo "HOST_UID=$(id -u)" > .env
+echo "HOST_GID=$(id -g)" >> .env
+```
 
-- 1.4. Add your timezone to the `.env` file:
-  ```bash
-  echo "TZ='UTC'" >> .env
-  ```
-  *The single and double quotes should remain in the command.*
+1.4. Add your timezone to the `.env` file:
+```bash
+echo "TZ='UTC'" >> .env
+```
+*The single and double quotes should remain in the command.*
 
-  > [!TIP]
-  > You can find a list of timezones here (use the `TZ identifier` column):
-  > [list of timezones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List).
+> [!TIP]
+> You can find a list of timezones here (use the `TZ identifier` column):
+> [list of timezones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List).
 
-- 1.5. Create the required folder structure:
-  ```bash
-  mkdir -p config/etc-pihole
-  mkdir -p config/etc-dnsmasq.d
-  ```
+1.5. Create the required folder structure:
+```bash
+mkdir -p config/etc-pihole
+mkdir -p config/etc-dnsmasq.d
+```
 
 ### 2. Start the container
 
-- 2.1. Start the container with the following command (if you are using the old version of Docker Compose, you may need to use `docker-compose` instead of `docker compose`).
-  ```bash
-  docker compose up -d
-  ```
+2.1. Start the container with the following command (if you are using the old version of Docker Compose, you may need to use `docker-compose` instead of `docker compose`).
+```bash
+docker compose up -d
+```
 
-- 2.2. Set the password for the web interface. **Change the password first!**<br>*It might take a few seconds for the container to start up. If you get an error, wait a few seconds and try again.*
-  ```bash
-  docker exec pihole-unbound pihole setpassword "your_password"
-  ```
+2.2. Set the password for the web interface. **Change the password first!**<br>*It might take a few seconds for the container to start up. If you get an error, wait a few seconds and try again.*
+```bash
+docker exec pihole-unbound pihole setpassword "your_password"
+```
 
-- 2.3. You can now log into the PiHole admin interface at `http://<server-ip-address>/admin`.<br>If you are on the same device as the container, you can use `http://localhost/admin`.
+2.3. You can now log into the PiHole admin interface at `http://<server-ip-address>/admin`.<br>If you are on the same device as the container, you can use `http://localhost/admin`.
 
 ### 3. Set PiHole as your DNS server
 
-- There are multiple ways to do this, it is recommended to follow the official PiHole FAQ for this, it has all the different ways explained.<br>https://discourse.pi-hole.net/t/how-do-i-configure-my-devices-to-use-pi-hole-as-their-dns-server/245
+There are multiple ways to do this, [it is recommended to follow the official PiHole FAQ](https://discourse.pi-hole.net/t/how-do-i-configure-my-devices-to-use-pi-hole-as-their-dns-server/245), it has all the different ways explained.
 
 ### 4. Verify DNS Resolution
 
-- After setup, verify Pi-hole and Unbound are working correctly:
-  ```bash
-  # Test Pi-hole DNS resolution
-  dig example.com @<server-ip-address>
+After setup, verify Pi-hole and Unbound are working correctly:
+```bash
+# Test Pi-hole DNS resolution
+dig example.com @<server-ip-address>
 
-  # Test Unbound as recursive resolver
-  docker exec pihole-unbound dig example.com @127.0.0.1 -p 5335
-  ```
+# Test Unbound as recursive resolver
+docker exec pihole-unbound dig example.com @127.0.0.1 -p 5335
+```
 
 ### 5. Add additional blocklists (optional but recommended)
 
-- By default, PiHole comes with [Steven Black's blocklist](https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts). This may or may not be enough to fit your needs.
+By default, PiHole comes with [Steven Black's blocklist](https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts). This may or may not be enough to fit your needs.
 
-- **(recommended)** In the PiHole admin interface (under `Lists`), you can add additional blocklists. I recommend this source: https://firebog.net/
+**(recommended)** In the PiHole admin interface (under `Lists`), you can add additional blocklists. I recommend this source: https://firebog.net/
 
 ### 6. Container updates
 
-- It is recommended to check for updates regularly. Run this to update the container:
-  ```bash
-  # Pull the latest image
-  docker compose pull
+It is recommended to check for updates regularly. Run this to update the container:
+```bash
+# Pull the latest image
+docker compose pull
 
-  # Rebuild and restart the container with the latest image
-  docker compose up -d --build
+# Rebuild and restart the container with the latest image
+docker compose up -d --build
 
-  # Clean up old images (optional)
-  docker image prune -f
-  ```
+# Clean up old images (optional)
+docker image prune -f
+```

--- a/README.md
+++ b/README.md
@@ -1,46 +1,96 @@
-# PiHole v6 with Unbound in a single Docker container
+# PiHole with Unbound in a single Docker container
 
-A single Docker container which contains both PiHole and Unbound.
+A single Docker container running both PiHole and Unbound.
+
+[![Docker Build Status](https://github.com/stinobytes/pihole-unbound/actions/workflows/dockerhub-build-push.yml/badge.svg)](https://github.com/stinobytes/pihole-unbound/actions/workflows/dockerhub-build-push.yml)
 
 This setup contains:
-- PiHole v6 ([official image](https://hub.docker.com/r/pihole/pihole))
-- Unbound
+- PiHole (using [official image](https://hub.docker.com/r/pihole/pihole)).
+- Unbound DNS resolver, configured with DNS over TLS.
+
+> [!NOTE]
+> This setup uses host network mode, which means the container shares the network stack with the host.
+> This is optimal for DNS services but means the container has direct access to the host network.
+
 
 ## Prerequisites
 
-- An operating system with Docker capabilities that runs 24/7 (I recommend a Raspberry Pi 4/5 or Intel NUC with Ubuntu Server but any system will do).
-- Have Docker and Docker Compose installed. ([installation guide](https://docs.docker.com/compose/install/))
+- An operating system with Docker capabilities that runs 24/7 (recommended: Raspberry Pi 4/5 or Intel NUC with Ubuntu Server)
+- Docker and Docker Compose installed ([installation guide](https://docs.docker.com/compose/install/))
 
 ## Setup
 
-> [!NOTE]
-> If you are installing this on Ubuntu (17.10+) or Fedora (33+), follow these steps first: https://github.com/pi-hole/docker-pi-hole/#installing-on-ubuntu-or-fedora.<br><br>
-> TLDR:<br>1. `sudo sed -r -i.orig 's/#?DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf`<br>
-> 2. `sudo sh -c 'rm /etc/resolv.conf && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf'`<br>
-> 3. `systemctl restart systemd-resolved`<br>
+> [!WARNING]
+> Before starting the container, ensure no other services are using ports 53 (DNS), 80 (HTTP), and 443 (HTTPS) on your host machine.
+>
+> If you are installing this on Ubuntu (17.10+) or Fedora (33+), follow these steps first: https://github.com/pi-hole/docker-pi-hole/#installing-on-ubuntu-or-fedora
+>
+> TLDR:
+> 1. `sudo sed -r -i.orig 's/#?DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf`
+> 2. `sudo sh -c 'rm /etc/resolv.conf && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf'`
+> 3. `systemctl restart systemd-resolved`
 
 ### 1. Prepare the environment
 
-- 1.1. In your terminal, navigate to the root of the project (same location where the `docker-compose.yaml` file is).<br>Create a .env file with your PID and GID. This is to ensure the container user permissions match the host file ownership.
+- 1.1. Create a folder for the project:
+  ```bash
+  mkdir pihole-unbound
+  cd pihole-unbound
+  ```
+
+- 1.2. Create the `docker-compose.yaml` file with the following content:
+  ```yaml
+  services:
+    pihole-unbound:
+      container_name: pihole-unbound
+      image: stinobytes/pihole-unbound:latest
+      network_mode: host
+      environment:
+        PIHOLE_UID: ${HOST_UID}
+        PIHOLE_GID: ${HOST_GID}
+        TZ: ${TZ}
+        FTLCONF_dns_listeningMode: "all"
+        FTLCONF_dns_upstreams: 127.0.0.1#5335
+      volumes:
+        - './config/etc-pihole:/etc/pihole'
+        - './config/etc-dnsmasq.d:/etc/dnsmasq.d'
+      cap_add:
+        - NET_BIND_SERVICE
+        - NET_ADMIN
+        - SYS_NICE
+      healthcheck:
+        test: ["CMD", "dig", "@127.0.0.1", "-p", "53", "pi.hole"]
+        interval: 30s
+        timeout: 10s
+        retries: 3
+      restart: unless-stopped
+  ```
+
+- 1.3. Create the `.env` file:
   ```bash
   echo "HOST_UID=$(id -u)" > .env
   echo "HOST_GID=$(id -g)" >> .env
   ```
 
-- 1.2. Next, add your timezone to the .env file. Change this to your own timezone.
-([list of timezones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones))<br>*The single and double quotes should remain in the command.*
+- 1.4. Add your timezone to the `.env` file:
   ```bash
   echo "TZ='UTC'" >> .env
   ```
+  *The single and double quotes should remain in the command.*
 
-- 1.3. Create the necessary folder structure.
+  > [!TIP]
+  > You can find a list of timezones here (use the `TZ identifier` column):
+  > [list of timezones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List).
+
+- 1.5. Create the required folder structure:
   ```bash
   mkdir -p config/etc-pihole
+  mkdir -p config/etc-dnsmasq.d
   ```
 
 ### 2. Start the container
 
-- 2.1. Start up the container with the following command. If you are using the old version of Docker Compose, you may need to use `docker-compose` instead of `docker compose`.
+- 2.1. Start the container with the following command (if you are using the old version of Docker Compose, you may need to use `docker-compose` instead of `docker compose`).
   ```bash
   docker compose up -d
   ```
@@ -56,8 +106,33 @@ This setup contains:
 
 - There are multiple ways to do this, it is recommended to follow the official PiHole FAQ for this, it has all the different ways explained.<br>https://discourse.pi-hole.net/t/how-do-i-configure-my-devices-to-use-pi-hole-as-their-dns-server/245
 
-### 4. (optional) Add additional blocklists
+### 4. Verify DNS Resolution
 
-- By default, PiHole comes with Steven Black's blocklist.
+- After setup, verify Pi-hole and Unbound are working correctly:
+  ```bash
+  # Test Pi-hole DNS resolution
+  dig example.com @<server-ip-address>
 
-- If you want to add additional blocklists, you can find them here: https://firebog.net/<br>Or google for new lists. You can add them in the PiHole admin interface.
+  # Test Unbound as recursive resolver
+  docker exec pihole-unbound dig example.com @127.0.0.1 -p 5335
+  ```
+
+### 5. Add additional blocklists (optional but recommended)
+
+- By default, PiHole comes with [Steven Black's blocklist](https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts). This may or may not be enough to fit your needs.
+
+- **(recommended)** In the PiHole admin interface (under `Lists`), you can add additional blocklists. I recommend this source: https://firebog.net/
+
+### 6. Container updates
+
+- It is recommended to check for updates regularly. Run this to update the container:
+  ```bash
+  # Pull the latest image
+  docker compose pull
+
+  # Rebuild and restart the container with the latest image
+  docker compose up -d --build
+
+  # Clean up old images (optional)
+  docker image prune -f
+  ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,16 +4,6 @@ services:
     network_mode: host
     build:
       context: ./src
-    ports:
-      # DNS Ports
-      - "53:53/tcp"
-      - "53:53/udp"
-      # Default HTTP Port
-      - "80:80/tcp"
-      # Default HTTPs Port. FTL will generate a self-signed certificate
-      - "443:443/tcp"
-      # Uncomment the below if using Pi-hole as your DHCP Server
-      #- "67:67/udp"
     environment:
       PIHOLE_UID: ${HOST_UID}
       PIHOLE_GID: ${HOST_GID}
@@ -22,10 +12,16 @@ services:
       FTLCONF_dns_upstreams: 127.0.0.1#5335
     volumes:
       - './config/etc-pihole:/etc/pihole'
+      - './config/etc-dnsmasq.d:/etc/dnsmasq.d'
     cap_add:
       # See https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
       # Required if you are using Pi-hole as your DHCP server, else not needed
       - NET_ADMIN
-      # Optional, uncomment if Pi-hole should get some more processing time
-      - SYS_NICE
+      - NET_BIND_SERVICE
+      - SYS_NICE # Optional, gives Pi-hole some more processing time
+    healthcheck:
+      test: ["CMD", "dig", "@127.0.0.1", "-p", "53", "pi.hole"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     restart: unless-stopped


### PR DESCRIPTION
This PR comes with a more comprehensive installation guide and improvements to the docker-compose file: 
- Port mappings are removed because they are redundant as the network mode is set as host. 
- Added a health check for the running container.