### PR TITLE
Security patch

### DIFF
--- a/.github/workflows/dockerhub-build-push-dev.yml
+++ b/.github/workflows/dockerhub-build-push-dev.yml
@@ -50,7 +50,7 @@ jobs:
           image-ref: ${{ secrets.DOCKERHUB_USERNAME }}/pihole-unbound:development
           format: "sarif"
           output: "trivy-results-dev.sarif"
-          severity: "CRITICAL,HIGH"
+          severity: "CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN"
           ignore-unfixed: true
           vuln-type: "os,library"
 

--- a/.github/workflows/dockerhub-build-push-dev.yml
+++ b/.github/workflows/dockerhub-build-push-dev.yml
@@ -1,0 +1,57 @@
+name: Docker Development Build
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/pihole-unbound
+          tags: |
+            type=raw,value=development
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./src
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ secrets.DOCKERHUB_USERNAME }}/pihole-unbound:development
+          format: "sarif"
+          output: "trivy-results-dev.sarif"
+          severity: "CRITICAL,HIGH"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: "trivy-results-dev.sarif"

--- a/.github/workflows/dockerhub-build-push-dev.yml
+++ b/.github/workflows/dockerhub-build-push-dev.yml
@@ -8,7 +8,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-push:
+  build-and-push-dev:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/dockerhub-build-push.yml
+++ b/.github/workflows/dockerhub-build-push.yml
@@ -9,6 +9,10 @@ on:
 
 jobs:
   build-and-push:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     runs-on: ubuntu-latest
 
     steps:
@@ -51,3 +55,9 @@ jobs:
           severity: "CRITICAL,HIGH"
           ignore-unfixed: true
           vuln-type: "os,library"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: "trivy-results.sarif"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# PiHole with Unbound in a single Docker container
+# Pi-hole with Unbound in a single Docker container
 
-A single Docker container running both PiHole and Unbound.
+A single Docker container running both Pi-hole and Unbound.
 
 [![Docker Build Status](https://github.com/stinobytes/pihole-unbound/actions/workflows/dockerhub-build-push.yml/badge.svg)](https://github.com/stinobytes/pihole-unbound/actions/workflows/dockerhub-build-push.yml)
 
 This setup contains:
-- PiHole (using the [official image](https://hub.docker.com/r/pihole/pihole)).
+- Pi-hole (using the [official image](https://hub.docker.com/r/pihole/pihole)).
 - Unbound DNS resolver, configured with DNS over TLS.
 
 > [!NOTE]
@@ -100,11 +100,11 @@ docker compose up -d
 docker exec pihole-unbound pihole setpassword "your_password"
 ```
 
-2.3. You can now log into the PiHole admin interface at `http://<server-ip-address>/admin`.<br>If you are on the same device as the container, you can use `http://localhost/admin`.
+2.3. You can now log into the Pi-hole admin interface at `http://<server-ip-address>/admin`.<br>If you are on the same device as the container, you can use `http://localhost/admin`.
 
-### 3. Set PiHole as your DNS server
+### 3. Set Pi-hole as your DNS server
 
-There are multiple ways to do this, [it is recommended to follow the official PiHole FAQ](https://discourse.pi-hole.net/t/how-do-i-configure-my-devices-to-use-pi-hole-as-their-dns-server/245). It has all the different ways explained.
+There are multiple ways to do this, [it is recommended to follow the official Pi-hole FAQ](https://discourse.pi-hole.net/t/how-do-i-configure-my-devices-to-use-pi-hole-as-their-dns-server/245). It has all the different ways explained.
 
 ### 4. Verify DNS resolution
 
@@ -119,9 +119,9 @@ docker exec pihole-unbound dig example.com @127.0.0.1 -p 5335
 
 ### 5. Add additional blocklists (optional but recommended)
 
-By default, PiHole comes with [Steven Black's blocklist](https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts). This may or may not be enough to fit your needs.
+By default, Pi-hole comes with [Steven Black's blocklist](https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts). This may or may not be enough to fit your needs.
 
-**(recommended)** In the PiHole admin interface (under `Lists`), you can add additional blocklists. I recommend this source: https://firebog.net/.
+**(recommended)** In the Pi-hole admin interface (under `Lists`), you can add additional blocklists. I recommend this source: https://firebog.net/.
 
 > [!TIP]
 > You can add multiple lists at once, seperated by a space. If you are using firebog, you can copy and paste multple lines from each section.

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,8 +1,8 @@
 FROM pihole/pihole:2025.04.0
 
 RUN apk update && \
-  apk add --no-cache \
-  unbound && \
+  apk upgrade xz-libs && \
+  apk add --no-cache unbound && \
   rm -rf /var/cache/apk/*
 
 COPY unbound.conf /etc/unbound/unbound.conf


### PR DESCRIPTION
This PR addresses a few issues to improve security for the project:

- Fix for vulnerability [CVE-2025-31115](https://security.alpinelinux.org/vuln/CVE-2025-31115): The base image used the unpatched version `5.4.5-r0` of `xz-libs` which contains a security issue with high severity ([CVE Record information](https://www.cve.org/CVERecord?id=CVE-2025-31115)). This is fixed by upgrading `xz-libs` in the Docker container to version `5.4.5-r1`, in which the vulnerability is patched.
- Improved CI pipeline with `Trivy vulnerability scanner` check to monitor for vulnerabilities with GitHub Security integration for both the `main` and `dev` branches.