### PR TITLE
Security patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 A single Docker container running both Pi-hole and Unbound.
 
 [![Docker Build Status](https://github.com/stinobytes/pihole-unbound/actions/workflows/dockerhub-build-push.yml/badge.svg)](https://github.com/stinobytes/pihole-unbound/actions/workflows/dockerhub-build-push.yml)
+[![Docker Pulls](https://img.shields.io/docker/pulls/stinobytes/pihole-unbound.svg)](https://hub.docker.com/r/stinobytes/pihole-unbound)
 
 This setup contains:
 - Pi-hole (using the [official image](https://hub.docker.com/r/pihole/pihole)).
-- Unbound DNS resolver, configured with DNS over TLS.
+- Unbound DNS resolver, configured with DNS over TLS (DoT) using Cloudflare as upstream DNS server.
 
 > [!NOTE]
 > This setup uses host network mode, which means the container shares the network stack with the host.

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -2,6 +2,7 @@ FROM pihole/pihole:2025.04.0
 
 RUN apk update && \
   apk upgrade xz-libs && \
+  apk upgrade libxml2 && \
   apk add --no-cache unbound && \
   rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
This PR addresses a security issue in one of the packages of the base pihole image:

- Fix for vulnerabilities [CVE-2025-32414](https://security.alpinelinux.org/vuln/CVE-2025-32414) and [CVE-2025-32415](https://security.alpinelinux.org/vuln/CVE-2025-32415): The base pihole image contained an unpatched version of libxml2 which had security issues. This is fixed by upgrading libxml2 in the Docker container.
