### PR TITLE
Patch for vulnerability CVE-2025-40775 in bind-tools

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,6 +3,7 @@ FROM pihole/pihole:2025.04.0
 RUN apk update && \
   apk upgrade xz-libs && \
   apk upgrade libxml2 && \
+  apk upgrade bind-tools && \
   apk add --no-cache unbound && \
   rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
This PR addresses a security issue in one of the packages of the base pihole image:

- Fix for vulnerability [CVE-2025-40775](https://security.alpinelinux.org/vuln/CVE-2025-40775): The base pihole image contained an unpatched version of bind-tools which had security issues. This is fixed by upgrading bind-tools in the Docker container.